### PR TITLE
AND-6321: Breadcrumbs fail to display when user navigates to the parent

### DIFF
--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxBrowseFolderFragment.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxBrowseFolderFragment.java
@@ -134,6 +134,7 @@ public class BoxBrowseFolderFragment extends BoxBrowseFragment {
          */
         public Builder(BoxFolder folder, BoxSession session) {
             mArgs.putString(ARG_ID, folder.getId());
+            mArgs.putString(ARG_NAME, folder.getName());
             mArgs.putString(ARG_USER_ID, session.getUserId());
         }
 


### PR DESCRIPTION
folder from a sub-folder through breadcrumbs
- Ensure that fragment is using folder name when passed