### PR TITLE
AND-7032 - New parameter for offline file access only

### DIFF
--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/BoxBrowseController.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/BoxBrowseController.java
@@ -115,7 +115,7 @@ public class BoxBrowseController implements BrowseController {
             thumbSize = BoxRequestsFile.DownloadThumbnail.SIZE_64;
         }
         try {
-            return mFileApi.getDownloadThumbnailRequest(downloadFile, fileId)
+            return mFileApi.getDownloadThumbnailRequest(downloadFile, fileId, false)
                     .setMinWidth(thumbSize)
                     .setMinHeight(thumbSize);
         } catch (IOException e) {


### PR DESCRIPTION
The server needs to differentiate when a file is accessed only to be available
for later access from the real file previewing. So a new parameter was made available
for that.